### PR TITLE
[FIX] Custom report - date fields error

### DIFF
--- a/app/Http/Requests/CustomAssetReportRequest.php
+++ b/app/Http/Requests/CustomAssetReportRequest.php
@@ -22,9 +22,6 @@ class CustomAssetReportRequest extends Request
     public function rules()
     {
         return [
-            'purchase_date'         => 'date|date_format:Y-m-d|nullable',
-            'checkout_date'         => 'date|date_format:Y-m-d|nullable',
-            'checkin_date'          => 'date|date_format:Y-m-d|nullable',
             'purchase_start'        => 'date|date_format:Y-m-d|nullable',
             'purchase_end'          => 'date|date_format:Y-m-d|nullable',
             'created_start'         => 'date|date_format:Y-m-d|nullable',


### PR DESCRIPTION
# Description
Custom report in v6.2.3 give Error if selected are fields: Purchase Date, Checkout Date, Last Checkin Date, Expected Checkin Date Reason is: date field format
![image](https://github.com/Robert-Azelis/snipe-it/assets/82208283/a10f692f-a790-4470-8905-c1580cca3e15)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* PHP version: 8.1
* MySQL version 10.6.5-MariaDB
* Webserver version IIS
* OS version


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
