### PR TITLE
[Improvement] Dashboard

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -274,63 +274,136 @@
 </div> <!--/row-->
 <div class="row">
     <div class="col-md-6">
-         <!-- Locations -->
-         <div class="box box-default">
-            <div class="box-header with-border">
-                <h2 class="box-title">{{ trans('general.asset') }} {{ trans('general.locations') }}</h2>
-                <div class="box-tools pull-right">
-                    <button type="button" class="btn btn-box-tool" data-widget="collapse">
-                        <i class="fas fa-minus" aria-hidden="true"></i>
-                        <span class="sr-only">{{ trans('general.collapse') }}</span>
-                    </button>
-                </div>
-            </div>
-            <!-- /.box-header -->
-            <div class="box-body">
-                <div class="row">
-                    <div class="col-md-12">
-                        <div class="table-responsive">
-                        <table
-                                data-cookie-id-table="dashLocationSummary"
-                                data-height="400"
-                                data-pagination="true"
-                                data-side-pagination="server"
-                                data-sort-order="desc"
-                                data-sort-field="assets_count"
-                                id="dashLocationSummary"
-                                class="table table-striped snipe-table"
-                                data-url="{{ route('api.locations.index', ['sort' => 'assets_count', 'order' => 'asc']) }}">
 
-                            <thead>
-                            <tr>
-                                <th class="col-sm-3" data-visible="true" data-field="name" data-formatter="locationsLinkFormatter" data-sortable="true">{{ trans('general.name') }}</th>
-                                
-                                <th class="col-sm-1" data-visible="true" data-field="assets_count" data-sortable="true">
-                                    <i class="fas fa-barcode" aria-hidden="true"></i>
-                                    <span class="sr-only">{{ trans('general.asset_count') }}</span>
-                                </th>
-                                <th class="col-sm-1" data-visible="true" data-field="assigned_assets_count" data-sortable="true">
-                                    
-                                    {{ trans('general.assigned') }}
-                                </th>
-                                <th class="col-sm-1" data-visible="true" data-field="users_count" data-sortable="true">
-                                    <i class="fas fa-users" aria-hidden="true"></i>
-                                    <span class="sr-only">{{ trans('general.people') }}</span>
-                                    
-                                </th>
-                                
-                            </tr>
-                            </thead>
-                        </table>
-                        </div>
-                    </div> <!-- /.col -->
-                    <div class="text-center col-md-12" style="padding-top: 10px;">
-                        <a href="{{ route('locations.index') }}" class="btn btn-primary btn-sm" style="width: 100%">{{ trans('general.viewall') }}</a>
-                    </div>
-                </div> <!-- /.row -->
+		@if ($snipeSettings->full_multiple_companies_support=='1')
+			 <!-- Companies -->	
+			<div class="box box-default">
+				<div class="box-header with-border">
+					<h2 class="box-title">{{ trans('general.companies') }}</h2>
+					<div class="box-tools pull-right">
+						<button type="button" class="btn btn-box-tool" data-widget="collapse">
+							<i class="fas fa-minus" aria-hidden="true"></i>
+							<span class="sr-only">{{ trans('general.collapse') }}</span>
+						</button>
+					</div>
+				</div>
+				<!-- /.box-header -->
+				<div class="box-body">
+					<div class="row">
+						<div class="col-md-12">
+							<div class="table-responsive">
+							<table
+									data-cookie-id-table="dashCompanySummary"
+									data-height="400"
+									data-pagination="true"
+									data-side-pagination="server"
+									data-sort-order="desc"
+									data-sort-field="assets_count"
+									id="dashCompanySummary"
+									class="table table-striped snipe-table"
+									data-url="{{ route('api.companies.index', ['sort' => 'assets_count', 'order' => 'asc']) }}">
 
-            </div><!-- /.box-body -->
-        </div> <!-- /.box -->
+								<thead>
+								<tr>
+									<th class="col-sm-3" data-visible="true" data-field="name" data-formatter="companiesLinkFormatter" data-sortable="true">{{ trans('general.name') }}</th>
+									<th class="col-sm-1" data-visible="true" data-field="users_count" data-sortable="true">
+										<i class="fas fa-users" aria-hidden="true"></i>
+										<span class="sr-only">{{ trans('general.people') }}</span>
+									</th>
+									<th class="col-sm-1" data-visible="true" data-field="assets_count" data-sortable="true">
+										<i class="fas fa-barcode" aria-hidden="true"></i>
+										<span class="sr-only">{{ trans('general.asset_count') }}</span>
+									</th>
+									<th class="col-sm-1" data-visible="true" data-field="accessories_count" data-sortable="true">
+										<i class="far fa-keyboard" aria-hidden="true"></i>
+										<span class="sr-only">{{ trans('general.accessories_count') }}</span>
+									</th>
+									<th class="col-sm-1" data-visible="true" data-field="consumables_count" data-sortable="true">
+										<i class="fas fa-tint" aria-hidden="true"></i>
+										<span class="sr-only">{{ trans('general.consumables_count') }}</span>
+									</th>
+									<th class="col-sm-1" data-visible="true" data-field="components_count" data-sortable="true">
+										<i class="far fa-hdd" aria-hidden="true"></i>
+										<span class="sr-only">{{ trans('general.components_count') }}</span>
+									</th>
+									<th class="col-sm-1" data-visible="true" data-field="licenses_count" data-sortable="true">
+										<i class="far fa-save" aria-hidden="true"></i>
+										<span class="sr-only">{{ trans('general.licenses_count') }}</span>
+									</th>
+								</tr>
+								</thead>
+							</table>
+							</div>
+						</div> <!-- /.col -->
+						<div class="text-center col-md-12" style="padding-top: 10px;">
+							<a href="{{ route('companies.index') }}" class="btn btn-primary btn-sm" style="width: 100%">{{ trans('general.viewall') }}</a>
+						</div>
+					</div> <!-- /.row -->
+
+				</div><!-- /.box-body -->
+			</div> <!-- /.box -->
+		
+		@else
+			 <!-- Locations -->
+			 <div class="box box-default">
+				<div class="box-header with-border">
+					<h2 class="box-title">{{ trans('general.locations') }}</h2>
+					<div class="box-tools pull-right">
+						<button type="button" class="btn btn-box-tool" data-widget="collapse">
+							<i class="fas fa-minus" aria-hidden="true"></i>
+							<span class="sr-only">{{ trans('general.collapse') }}</span>
+						</button>
+					</div>
+				</div>
+				<!-- /.box-header -->
+				<div class="box-body">
+					<div class="row">
+						<div class="col-md-12">
+							<div class="table-responsive">
+							<table
+									data-cookie-id-table="dashLocationSummary"
+									data-height="400"
+									data-pagination="true"
+									data-side-pagination="server"
+									data-sort-order="desc"
+									data-sort-field="assets_count"
+									id="dashLocationSummary"
+									class="table table-striped snipe-table"
+									data-url="{{ route('api.locations.index', ['sort' => 'assets_count', 'order' => 'asc']) }}">
+
+								<thead>
+								<tr>
+									<th class="col-sm-3" data-visible="true" data-field="name" data-formatter="locationsLinkFormatter" data-sortable="true">{{ trans('general.name') }}</th>
+									
+									<th class="col-sm-1" data-visible="true" data-field="assets_count" data-sortable="true">
+										<i class="fas fa-barcode" aria-hidden="true"></i>
+										<span class="sr-only">{{ trans('general.asset_count') }}</span>
+									</th>
+									<th class="col-sm-1" data-visible="true" data-field="assigned_assets_count" data-sortable="true">
+										
+										{{ trans('general.assigned') }}
+									</th>
+									<th class="col-sm-1" data-visible="true" data-field="users_count" data-sortable="true">
+										<i class="fas fa-users" aria-hidden="true"></i>
+										<span class="sr-only">{{ trans('general.people') }}</span>
+										
+									</th>
+									
+								</tr>
+								</thead>
+							</table>
+							</div>
+						</div> <!-- /.col -->
+						<div class="text-center col-md-12" style="padding-top: 10px;">
+							<a href="{{ route('locations.index') }}" class="btn btn-primary btn-sm" style="width: 100%">{{ trans('general.viewall') }}</a>
+						</div>
+					</div> <!-- /.row -->
+
+				</div><!-- /.box-body -->
+			</div> <!-- /.box -->
+
+		@endif
+			
     </div>
     <div class="col-md-6">
 


### PR DESCRIPTION
# Description
If multicompany option is enabled much more important for admin is to see on dashboard list of companies instead of locations.  
In other way if multicompanies option is disabled then locations are displayed.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

**Test Configuration**:
* PHP version: 8.1
* MySQL version 10.6.5-MariaDB
* Webserver version IIS
* Web browser: MS Edge, Chrome


# Checklist:

- [x] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [x] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
